### PR TITLE
feat: add method clear_unused_rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Add method `clear_unused_rule()` to remove unused validation and filter rule.
+- Add method `get_validations()` and `get_filters()`.
+
 ### Fixed
-- `filter_out` return merge with fields.
+- `filter_out()` return merge with fields.
 
 ## [0.2.1] - 2022-01-02
 ### Added

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -249,4 +249,38 @@ final class Validator
 
         return true;
     }
+
+    /**
+     * Remove validation and filter rule, when not in fields input.
+     */
+    public function clear_unused_rule(): self
+    {
+        // remove unuse validation rule
+        $this->validations = array_filter($this->validations, fn($field) => in_array($field, $this->fields));
+        
+        // remove unuse filter rule
+        $this->filters = array_filter($this->filters, fn($field) => in_array($field, $this->fields));
+
+        return $this;
+    }
+
+    /** 
+     * Get validations rule.
+     * 
+     * @return Valid[] Validations rule
+     */
+    public function get_validations(): array
+    {
+        return $this->validations;
+    }
+
+    /** 
+     * Get filters rule.
+     * 
+     * @return Filter[] Filters rule
+     */
+    public function get_filters(): array
+    {
+        return $this->filters;
+    }
 }

--- a/tests/Unit/Validation.php
+++ b/tests/Unit/Validation.php
@@ -259,3 +259,28 @@ it('can get error message when valadation is fallen using method validOrError', 
 
     expect($valid->validOrError())->toHaveCount(1);
 });
+
+// romove unuse rule
+it('can remove unuse validation and filter rule', function () {
+    $valid = new Validator(['test' => 'test']);
+
+    $valid->field('no_test')->required();
+    $valid->filter('no_test')->upper_case();
+    
+    // reomove unuse rule
+    $valid->clear_unused_rule();
+
+    expect($valid->get_validations())->toHaveCount(0);
+    expect($valid->get_filters())->toHaveCount(0);
+});
+
+// check validation and filter rule
+it('can remove unuse validation and filter rule', function () {
+    $valid = new Validator(['test' => 'test']);
+
+    $valid->field('no_test')->required();
+    $valid->filter('no_test')->upper_case();
+    
+    expect($valid->get_validations())->toHaveProperties('no_test');
+    expect($valid->get_filters())->toHaveProperties('no_test')
+});


### PR DESCRIPTION
- Add method `clear_unused_rule()` to remove unused validation and filter rule.
- Add method `get_validations()` and `get_filters()`.